### PR TITLE
Updated for new scroll syntax

### DIFF
--- a/_posts/docs/2016-10-12-syntax.md
+++ b/_posts/docs/2016-10-12-syntax.md
@@ -283,27 +283,27 @@ var mouse = robot.getMousePos();
 console.log("Mouse is at x:" + mouse.x + " y:" + mouse.y);
 {% endhighlight %}
 
-## scrollMouse(magnitude, direction)
+## scrollMouse(x, y)
 
-Scrolls the mouse either up or down.
+Scrolls the mouse in any direction.
 
 **Arguments**
 
 **Argument** | **Description** | **Default**
 --------|-----------------|-------------
-`magnitude` | The amount to scroll. | None
-`direction` | Accepts down or up. | None
+`x` | The magnitude and direction of the scroll left and right. Left is negative. | None
+`y` | The magnitude and direction of the scroll up and down. Down is negative. | None
 
 **Examples**
 
 {% highlight javascript %}
 var robot = require("robotjs");
 
-robot.scrollMouse(50, "up");
+robot.scrollMouse(50, 0);
 
 setTimeout(function()
 {
-    robot.scrollMouse(50, "down");
+    robot.scrollMouse(50, 0);
 }, 2000);
 {% endhighlight %}
 


### PR DESCRIPTION
This fixes the docs for the new scroll using X and Y instead of "magnitude" and "up and down"