### PR TITLE
Fixed typos

### DIFF
--- a/_posts/docs/2016-10-12-syntax.md
+++ b/_posts/docs/2016-10-12-syntax.md
@@ -123,7 +123,7 @@ Press a single key.
 **Argument** | **Description** | **Default**
 --------|-----------------|-------------
 `key` | See [keys](/docs/syntax#keys). | None
-`modified` | String or an array. Accepts alt, command (win), control, and shift. | None
+`modifier` | String or an array. Accepts alt, command (mac), control, and shift. | None
 
 ## keyToggle(key, down, [modifier])
 


### PR DESCRIPTION
Changed:
- `modified` -> `modifier`,
- `win` -> `mac`, as the `command` key is on macOS, not Windows 😉.